### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,9 @@ sudo apt-get install tor -qq
 # install docker
 sudo apt install docker.io;
 
+# install  containerd
+sudo apt install containerd -y
+
 # pull splah docker
 sudo docker pull scrapinghub/splash;
 


### PR DESCRIPTION
Updarte Fix Erros when install.

The following packages have unmet dependencies:
 docker.io : Depends: containerd (>= 1.2.6-0ubuntu1~)
E: Unable to correct problems, you have held broken packages.
