### PR TITLE
Character encoding error 

### DIFF
--- a/splash_manager.py
+++ b/splash_manager.py
@@ -791,7 +791,7 @@ def test_splash_docker(container_id):
 def tests():
     print()
     print('Splash List:')
-    print(get_all_running_splash_docker(r_text=True))
+    print(get_all_running_splash_docker(r_text=True).encode(encoding="ascii",errors="ignore"))
     print()
 
     containers_id = get_all_running_splash_docker()

--- a/splash_manager.py
+++ b/splash_manager.py
@@ -323,7 +323,6 @@ def api_delete_proxy(proxy_name): ################################
         res = {'name': proxy_name}
         return (res, 200)
 
-#### ---- ####
 
 # # # # # # # # # # #
 # #     SPLASH    # #
@@ -512,7 +511,7 @@ def api_delete_splash_docker(splash_name):
         return (res, 200)
 
 # # # # # # # # # # # # # # # # #
-# # - - - -    CORE   - - - - # #
+#              CORE             #
 # # # # # # # # # # # # # # # # #
 
 def kill_all_splash_dockers():

--- a/splash_manager.py
+++ b/splash_manager.py
@@ -539,7 +539,7 @@ class SplashManager(object):
         self.version = 'v0.1'
 
         # LAUNCH SPLASH DOCKERS #
-        print('Lauching all Splash dockers ...')
+        print('Launching all Splash dockers ...')
         print()
         if not check_docker_install():
             print('Error: docker install')
@@ -681,7 +681,7 @@ class SplashManager(object):
             self.add_splash_container(container_name, proxy_name, cpu, memory, maxrss, description=description)
             for port in ports:
                 if proxy_name not in self.get_all_proxies_name() and proxy_name != 'None': # # TODO: add me in launch_splash?
-                    print('Error: Unknow proxy, {}'.format(proxy_name)) # # TODO: handle error
+                    print('Error: Unknown proxy, {}'.format(proxy_name)) # # TODO: handle error
                 else:
                     self.launch_splash(container_name, port)
 
@@ -699,7 +699,7 @@ class SplashManager(object):
         # check if container exist
         #if splash_name:
         if not self.get_splash_container_by_name(splash_name):
-            return ({'status': 'error', 'reason': f'Unknow Splash Container Name: {splash_name}'}, 400)
+            return ({'status': 'error', 'reason': f'Unknown Splash Container Name: {splash_name}'}, 400)
         #else:
             # # TODO: search port
         #    pass


### PR DESCRIPTION
When trying to run ./LAUNCH.sh -t from a disposable VM, I came across this error which appeared to be related to character encoding. This pull request adds an encoding filter to alleviate issues where the locale for the installation is not compatible with whatever the output is.

Splash List:
Traceback (most recent call last):
  File "./splash_manager.py", line 823, in <module>
    tests()
  File "./splash_manager.py", line 794, in tests
    print(get_all_running_splash_docker(r_text=True))
UnicodeEncodeError: 'latin-1' codec can't encode character '\u2026' in position 56: ordinal not in range(256)

Also fixed some typographical errors whilst I was at it.